### PR TITLE
Fixed scale detection

### DIFF
--- a/tools/gltf-avatar-exporter/src/scene/correction-steps/fixBonesScale.ts
+++ b/tools/gltf-avatar-exporter/src/scene/correction-steps/fixBonesScale.ts
@@ -18,8 +18,8 @@ export const fixBonesScaleCorrectionStep: Step = {
       level: "info",
       message: `Bones size: x: ${xBonesSize}, y: ${yBonesSize}, z: ${zBonesSize}`,
     };
-    const bonesAre100TimesTooLarge = zBonesSize > 10 || yBonesSize > 10;
-    const bonesAre1000TimesTooLarge = zBonesSize > 100 || yBonesSize > 100;
+    const bonesAre100TimesTooLarge = zBonesSize > 100 || yBonesSize > 100;
+    const bonesAre1000TimesTooLarge = zBonesSize > 1000 || yBonesSize > 1000;
 
     if (!bonesAre100TimesTooLarge) {
       return {

--- a/tools/gltf-avatar-exporter/src/scene/correction-steps/fixMeshScale.ts
+++ b/tools/gltf-avatar-exporter/src/scene/correction-steps/fixMeshScale.ts
@@ -21,8 +21,8 @@ export const fixMeshScaleCorrectionStep: Step = {
       level: "info",
       message: `Bones size: x: ${xBonesSize}, y: ${yBonesSize}, z: ${zBonesSize}`,
     };
-    const bonesAre100TimesTooLarge = zBonesSize > 10 || yBonesSize > 10;
-    const bonesAre1000TimesTooLarge = zBonesSize > 100 || yBonesSize > 100;
+    const bonesAre100TimesTooLarge = zBonesSize > 100 || yBonesSize > 100;
+    const bonesAre1000TimesTooLarge = zBonesSize > 1000 || yBonesSize > 1000;
 
     if (!bonesAre100TimesTooLarge) {
       return {


### PR DESCRIPTION
Fixes the scale detection. Meshes that were 100x the scale (e.g. `160`) were detected as 1000x (expected to be ~`1600`).

**What kind of change does your PR introduce?** (check at least one)

- [x] Bugfix
