### PR TITLE
Support TGA and flip bitmaps

### DIFF
--- a/tools/gltf-avatar-exporter/src/scene/ImportView.ts
+++ b/tools/gltf-avatar-exporter/src/scene/ImportView.ts
@@ -1,4 +1,5 @@
 import { Group, LoadingManager, SkinnedMesh, Vector3 } from "three";
+import { TGALoader } from "three/examples/jsm/loaders/TGALoader.js";
 
 import { LoggerView } from "../logger/LoggerView";
 
@@ -102,12 +103,16 @@ export class ImportView extends QuadrantScene {
   }
 
   private async loadModelFromBuffer(buffer: ArrayBuffer, name: string): Promise<void> {
-    const { group } = await this.modelLoader.loadFromBuffer(buffer, "");
+    const importViewLoadingManager = new LoadingManager();
+    importViewLoadingManager.addHandler(/\.tga$/i, new TGALoader(importViewLoadingManager));
+    const { group } = await this.modelLoader.loadFromBuffer(buffer, "", importViewLoadingManager);
+
     if (group) {
       group.traverse((child) => {
-        if (child.type === "SkinnedMesh") {
-          (child as SkinnedMesh).receiveShadow = true;
-          (child as SkinnedMesh).castShadow = true;
+        const asSkinnedMesh = child as SkinnedMesh;
+        if (asSkinnedMesh.isSkinnedMesh) {
+          asSkinnedMesh.receiveShadow = true;
+          asSkinnedMesh.castShadow = true;
         }
       });
 
@@ -126,6 +131,7 @@ export class ImportView extends QuadrantScene {
     }
 
     const loadingManager = new LoadingManager();
+    loadingManager.addHandler(/\.tga$/i, new TGALoader(loadingManager));
     let hasAssetsToLoad = false;
     loadingManager.onStart = () => {
       hasAssetsToLoad = true;

--- a/tools/gltf-avatar-exporter/src/scene/correction-steps/fixBitmapTextures.ts
+++ b/tools/gltf-avatar-exporter/src/scene/correction-steps/fixBitmapTextures.ts
@@ -1,0 +1,107 @@
+import * as THREE from "three";
+import { Group, Texture } from "three";
+
+import { forEachMapKey } from "./materials/forEachMapKey";
+import { Step } from "./types";
+
+function fixTexture(texture: Texture): Texture | null {
+  if (
+    texture.image &&
+    typeof texture.image === "object" &&
+    texture.flipY &&
+    texture.image.data &&
+    texture.image.data instanceof Uint8Array
+  ) {
+    const image = texture.image;
+    const data = image.data;
+    const newData = [];
+    // Copy the data into a new array, but with rows reversed
+    for (let i = 0; i < data.length; i += image.width * 4) {
+      const row = data.slice(i, i + image.width * 4);
+      newData.unshift(...row);
+    }
+
+    const clamped = new Uint8ClampedArray(newData);
+    const imageSrc = new ImageData(clamped, image.width, image.height);
+    const canvas = document.createElement("canvas");
+    canvas.width = image.width;
+    canvas.height = image.height;
+    const context = canvas.getContext("2d");
+    if (!context) {
+      return null;
+    }
+    context.putImageData(imageSrc, 0, 0);
+    const imageData = context.getImageData(0, 0, image.width, image.height);
+    const sanitizedTexture = new THREE.Texture();
+    sanitizedTexture.image = imageData;
+    sanitizedTexture.needsUpdate = true;
+    return sanitizedTexture;
+  }
+  return null;
+}
+
+function fixMaterial(material: THREE.Material): Array<string> {
+  const flippedTextures: Array<string> = [];
+  forEachMapKey(material, (key, texture) => {
+    const fixedTexture = fixTexture(texture);
+    if (fixedTexture) {
+      flippedTextures.push(`${texture.name} (${key})`);
+      (material as any)[key] = fixedTexture;
+    }
+  });
+  return flippedTextures;
+}
+
+export const fixFlippedBitmapTexturesCorrectionStep: Step = {
+  name: "fixFlippedBitmapTextures",
+  action: (group: Group) => {
+    const flippedTextureNames: Array<string> = [];
+
+    group.traverse((child) => {
+      const asSkinnedMesh = child as THREE.SkinnedMesh;
+      if (asSkinnedMesh.isSkinnedMesh) {
+        const originalMaterial = asSkinnedMesh.material;
+        if (Array.isArray(originalMaterial)) {
+          originalMaterial.forEach((innerMaterial) => {
+            const flippedTextures = fixMaterial(innerMaterial);
+            for (const flippedTextureName of flippedTextures) {
+              flippedTextureNames.push(
+                `Flipped texture for ${asSkinnedMesh.name} - ${innerMaterial.name} - ${flippedTextureName}`,
+              );
+            }
+          });
+        } else {
+          const flippedTextures = fixMaterial(originalMaterial);
+          for (const flippedTextureName of flippedTextures) {
+            flippedTextureNames.push(
+              `Flipped texture for ${asSkinnedMesh.name} - ${originalMaterial.name} - ${flippedTextureName}`,
+            );
+          }
+        }
+      }
+    });
+
+    if (flippedTextureNames.length === 0) {
+      return {
+        didApply: false,
+        topLevelMessage: {
+          level: "info",
+          message: "No materials with missing textures found.",
+        },
+      };
+    }
+
+    return {
+      didApply: true,
+      topLevelMessage: {
+        level: "info",
+        message:
+          "Detected at least one material with a missing texture. Replaced with placeholder(s).",
+      },
+      logs: flippedTextureNames.map((name) => ({
+        level: "error",
+        message: name,
+      })),
+    };
+  },
+};

--- a/tools/gltf-avatar-exporter/src/scene/correction-steps/materials/forEachMapKey.ts
+++ b/tools/gltf-avatar-exporter/src/scene/correction-steps/materials/forEachMapKey.ts
@@ -1,0 +1,44 @@
+import { Material, Texture } from "three";
+import * as THREE from "three";
+
+import {
+  lambertMaterialTextureKeys,
+  phongMaterialTextureKeys,
+  physicalMaterialTextureKeys,
+  standardMaterialTextureKeys,
+} from "./mapKeys";
+
+export function forEachMapKey(
+  material: Material,
+  callback: (key: string, texture: Texture) => void,
+) {
+  if (material instanceof THREE.MeshLambertMaterial) {
+    for (const key of lambertMaterialTextureKeys) {
+      const texture = material[key];
+      if (texture) {
+        callback(key, texture);
+      }
+    }
+  } else if (material instanceof THREE.MeshStandardMaterial) {
+    for (const key of standardMaterialTextureKeys) {
+      const texture = material[key];
+      if (texture) {
+        callback(key, texture);
+      }
+    }
+  } else if (material instanceof THREE.MeshPhysicalMaterial) {
+    for (const key of physicalMaterialTextureKeys) {
+      const texture = material[key];
+      if (texture) {
+        callback(key, texture);
+      }
+    }
+  } else if (material instanceof THREE.MeshPhongMaterial) {
+    for (const key of phongMaterialTextureKeys) {
+      const texture = material[key];
+      if (texture) {
+        callback(key, texture);
+      }
+    }
+  }
+}

--- a/tools/gltf-avatar-exporter/src/scene/correction-steps/materials/mapKeys.ts
+++ b/tools/gltf-avatar-exporter/src/scene/correction-steps/materials/mapKeys.ts
@@ -1,0 +1,123 @@
+export const lambertMaterialTextureKeys: Array<
+  | "bumpMap"
+  | "displacementMap"
+  | "emissiveMap"
+  | "map"
+  | "lightMap"
+  | "normalMap"
+  | "aoMap"
+  | "specularMap"
+  | "alphaMap"
+  | "envMap"
+> = [
+  "bumpMap",
+  "displacementMap",
+  "emissiveMap",
+  "map",
+  "lightMap",
+  "normalMap",
+  "aoMap",
+  "specularMap",
+  "alphaMap",
+  "envMap",
+];
+
+export const standardMaterialTextureKeys: Array<
+  | "map"
+  | "lightMap"
+  | "aoMap"
+  | "emissiveMap"
+  | "bumpMap"
+  | "normalMap"
+  | "displacementMap"
+  | "roughnessMap"
+  | "metalnessMap"
+  | "alphaMap"
+  | "envMap"
+> = [
+  "map",
+  "lightMap",
+  "aoMap",
+  "emissiveMap",
+  "bumpMap",
+  "normalMap",
+  "displacementMap",
+  "roughnessMap",
+  "metalnessMap",
+  "alphaMap",
+  "envMap",
+];
+
+export const physicalMaterialTextureKeys: Array<
+  | "clearcoatMap"
+  | "clearcoatRoughnessMap"
+  | "clearcoatNormalMap"
+  | "sheenColorMap"
+  | "sheenRoughnessMap"
+  | "transmissionMap"
+  | "thicknessMap"
+  | "specularIntensityMap"
+  | "specularColorMap"
+  | "iridescenceMap"
+  | "iridescenceThicknessMap"
+  | "anisotropyMap"
+  | "map"
+  | "lightMap"
+  | "aoMap"
+  | "emissiveMap"
+  | "bumpMap"
+  | "normalMap"
+  | "displacementMap"
+  | "roughnessMap"
+  | "metalnessMap"
+  | "alphaMap"
+  | "envMap"
+> = [
+  "clearcoatMap",
+  "clearcoatRoughnessMap",
+  "clearcoatNormalMap",
+  "sheenColorMap",
+  "sheenRoughnessMap",
+  "transmissionMap",
+  "thicknessMap",
+  "specularIntensityMap",
+  "specularColorMap",
+  "iridescenceMap",
+  "iridescenceThicknessMap",
+  "anisotropyMap",
+  "map",
+  "lightMap",
+  "aoMap",
+  "emissiveMap",
+  "bumpMap",
+  "normalMap",
+  "displacementMap",
+  "roughnessMap",
+  "metalnessMap",
+  "alphaMap",
+  "envMap",
+];
+
+export const phongMaterialTextureKeys: Array<
+  | "map"
+  | "lightMap"
+  | "aoMap"
+  | "emissiveMap"
+  | "bumpMap"
+  | "normalMap"
+  | "displacementMap"
+  | "specularMap"
+  | "alphaMap"
+  | "envMap"
+> = [
+  "map",
+  "lightMap",
+  "aoMap",
+  "emissiveMap",
+  "bumpMap",
+  "normalMap",
+  "displacementMap",
+  "specularMap",
+  "alphaMap",
+  "envMap",
+];

--- a/tools/gltf-avatar-exporter/src/scene/correction-steps/placeholderMissingTextures.ts
+++ b/tools/gltf-avatar-exporter/src/scene/correction-steps/placeholderMissingTextures.ts
@@ -1,9 +1,10 @@
 import * as THREE from "three";
 import { Group, Texture } from "three";
 
+import { forEachMapKey } from "./materials/forEachMapKey";
 import { Step } from "./types";
 
-function fixMap(texture: Texture, setDefaultColorIfMissing: boolean = false): Texture | null {
+function fixTexture(texture: Texture, setDefaultColorIfMissing: boolean = false): Texture | null {
   if (!texture.image) {
     // Replace with a placeholder texture (all white)
     const placeholderTexture = new THREE.Texture();
@@ -21,178 +22,17 @@ function fixMap(texture: Texture, setDefaultColorIfMissing: boolean = false): Te
   return null;
 }
 
-const lambertMaterialTextureKeys: Array<
-  | "bumpMap"
-  | "displacementMap"
-  | "emissiveMap"
-  | "map"
-  | "lightMap"
-  | "normalMap"
-  | "aoMap"
-  | "specularMap"
-  | "alphaMap"
-  | "envMap"
-> = [
-  "bumpMap",
-  "displacementMap",
-  "emissiveMap",
-  "map",
-  "lightMap",
-  "normalMap",
-  "aoMap",
-  "specularMap",
-  "alphaMap",
-  "envMap",
-];
-
-const standardMaterialTextureKeys: Array<
-  | "map"
-  | "lightMap"
-  | "aoMap"
-  | "emissiveMap"
-  | "bumpMap"
-  | "normalMap"
-  | "displacementMap"
-  | "roughnessMap"
-  | "metalnessMap"
-  | "alphaMap"
-  | "envMap"
-> = [
-  "map",
-  "lightMap",
-  "aoMap",
-  "emissiveMap",
-  "bumpMap",
-  "normalMap",
-  "displacementMap",
-  "roughnessMap",
-  "metalnessMap",
-  "alphaMap",
-  "envMap",
-];
-
-const physicalMaterialTextureKeys: Array<
-  | "clearcoatMap"
-  | "clearcoatRoughnessMap"
-  | "clearcoatNormalMap"
-  | "sheenColorMap"
-  | "sheenRoughnessMap"
-  | "transmissionMap"
-  | "thicknessMap"
-  | "specularIntensityMap"
-  | "specularColorMap"
-  | "iridescenceMap"
-  | "iridescenceThicknessMap"
-  | "anisotropyMap"
-  | "map"
-  | "lightMap"
-  | "aoMap"
-  | "emissiveMap"
-  | "bumpMap"
-  | "normalMap"
-  | "displacementMap"
-  | "roughnessMap"
-  | "metalnessMap"
-  | "alphaMap"
-  | "envMap"
-> = [
-  "clearcoatMap",
-  "clearcoatRoughnessMap",
-  "clearcoatNormalMap",
-  "sheenColorMap",
-  "sheenRoughnessMap",
-  "transmissionMap",
-  "thicknessMap",
-  "specularIntensityMap",
-  "specularColorMap",
-  "iridescenceMap",
-  "iridescenceThicknessMap",
-  "anisotropyMap",
-  "map",
-  "lightMap",
-  "aoMap",
-  "emissiveMap",
-  "bumpMap",
-  "normalMap",
-  "displacementMap",
-  "roughnessMap",
-  "metalnessMap",
-  "alphaMap",
-  "envMap",
-];
-
-const phongMaterialTextureKeys: Array<
-  | "map"
-  | "lightMap"
-  | "aoMap"
-  | "emissiveMap"
-  | "bumpMap"
-  | "normalMap"
-  | "displacementMap"
-  | "specularMap"
-  | "alphaMap"
-  | "envMap"
-> = [
-  "map",
-  "lightMap",
-  "aoMap",
-  "emissiveMap",
-  "bumpMap",
-  "normalMap",
-  "displacementMap",
-  "specularMap",
-  "alphaMap",
-  "envMap",
-];
-
 function fixMaterial(material: THREE.Material): Array<string> {
   const missingTextures: Array<string> = [];
+
   // Identify missing textures (all textures should be embedded so the texture should already be loaded)
-  if (material instanceof THREE.MeshLambertMaterial) {
-    for (const key of lambertMaterialTextureKeys) {
-      const texture = material[key];
-      if (texture) {
-        const fixedMap = fixMap(texture, key === "map");
-        if (fixedMap) {
-          material[key] = fixedMap;
-          missingTextures.push(`${texture.name} (${key})`);
-        }
-      }
+  forEachMapKey(material, (key, texture) => {
+    const fixedTexture = fixTexture(texture, key === "map");
+    if (fixedTexture) {
+      (material as any)[key] = fixedTexture;
+      missingTextures.push(`${texture.name} (${key})`);
     }
-  } else if (material instanceof THREE.MeshStandardMaterial) {
-    for (const key of standardMaterialTextureKeys) {
-      const texture = material[key];
-      if (texture) {
-        const fixedMap = fixMap(texture, key === "map");
-        if (fixedMap) {
-          material[key] = fixedMap;
-          missingTextures.push(`${texture.name} (${key})`);
-        }
-      }
-    }
-  } else if (material instanceof THREE.MeshPhysicalMaterial) {
-    for (const key of physicalMaterialTextureKeys) {
-      const texture = material[key];
-      if (texture) {
-        const fixedMap = fixMap(texture);
-        if (fixedMap) {
-          material[key] = fixedMap;
-          missingTextures.push(`${texture.name} (${key})`);
-        }
-      }
-    }
-  } else if (material instanceof THREE.MeshPhongMaterial) {
-    for (const key of phongMaterialTextureKeys) {
-      const texture = material[key];
-      if (texture) {
-        const fixedMap = fixMap(texture, key === "map");
-        if (fixedMap) {
-          material[key] = fixedMap;
-          missingTextures.push(`${texture.name} (${key})`);
-        }
-      }
-    }
-  }
+  });
   return missingTextures;
 }
 

--- a/tools/gltf-avatar-exporter/src/scene/correction-steps/runFixes.ts
+++ b/tools/gltf-avatar-exporter/src/scene/correction-steps/runFixes.ts
@@ -1,5 +1,6 @@
 import { boneDedupingCorrectionStep } from "./boneDeduping";
 import { connectRootCorrectionStep } from "./connectRoot";
+import { fixFlippedBitmapTexturesCorrectionStep } from "./fixBitmapTextures";
 import { fixBonesScaleCorrectionStep } from "./fixBonesScale";
 import { fixMeshScaleCorrectionStep } from "./fixMeshScale";
 import { levelOfDetailDedupingCorrectionStep } from "./lodDeduping";
@@ -25,6 +26,7 @@ export const correctionSteps = [
   rotateRootCorrectionStep,
   rotatePelvisCorrectionStep,
   removeVertexColorsCorrectionStep,
+  fixFlippedBitmapTexturesCorrectionStep,
   placeholderMissingTexturesCorrectionStep,
   replaceIncompatibleMaterialsCorrectionStep,
   removeTransparencyFromMaterialsCorrectionStep,


### PR DESCRIPTION
Adds support for embedded TGA textures and fixes an issue where textures (most likely TGAs) are flipped, but were not being exported and reimported respecting flipping.

**What kind of change does your PR introduce?** (check at least one)

- [x] Feature
