### PR TITLE
provides documentation for the gltf-avatar-exporter tool

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.glb filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text

--- a/tools/gltf-avatar-exporter/docs/README.md
+++ b/tools/gltf-avatar-exporter/docs/README.md
@@ -2,7 +2,11 @@
 
 ## About this guide:
 
-This guide aims to show you how to use the [**`gltf-avatar-exporter`**](https://mml-io.github.io/avatar-tools/main/tools/gltf-avatar-exporter/) Avatar Tool to rig any character of your choice from [Mixamo](https://www.mixamo.com) using [Blender](https://www.blender.org/download/) and the [Auto Rig Pro](https://blendermarket.com/products/auto-rig-pro) plugin, to get the character ready to be used in any M-Squared or Unreal experiences, and then how to use the [MML Editor](https://mmleditor.com) to create an `MML Character Description` with your brand new rigged model.
+This guide aims to show you how to use the [**`gltf-avatar-exporter`**](https://mml-io.github.io/avatar-tools/main/tools/gltf-avatar-exporter/) Avatar Tool to rig any character of your choice using [Blender](https://www.blender.org/download/) and the [Auto Rig Pro](https://blendermarket.com/products/auto-rig-pro) plugin, to get the character ready to be used in any M-Squared or Unreal experiences, and then how to use the [MML Editor](https://mmleditor.com) to create an `MML Character Description` with your brand new rigged model.
+
+This documentation shows this process using an asset picked from [Mixamo](https://www.mixamo.com) as an example not only for being a well-known 3D character source but also as an opportunity to illustrate how to unparent a character's mesh from its current armature to create a new rig.
+
+In case you're following this guide with a character that has no armature (just the 3D mesh with no skeleton, vertex groups, or modifiers), then steps `1` to `7` of the guide may be skipped.
 
 The software versions being used while writing this guide are:
 - Blender: `v3.6.5`

--- a/tools/gltf-avatar-exporter/docs/README.md
+++ b/tools/gltf-avatar-exporter/docs/README.md
@@ -1,0 +1,108 @@
+# Using Mixamo characters on M-Squared Unreal Experiences
+
+## About this guide:
+
+This guide aims to show you how to use the [**`gltf-avatar-exporter`**](https://mml-io.github.io/avatar-tools/main/tools/gltf-avatar-exporter/) Avatar Tool to rig any character of your choice from [Mixamo](https://www.mixamo.com) using [Blender](https://www.blender.org/download/) and the [Auto Rig Pro](https://blendermarket.com/products/auto-rig-pro) plugin, to get the character ready to be used in any M-Squared or Unreal experiences, and then how to use the [MML Editor](https://mmleditor.com) to create an `MML Character Description` with your brand new rigged model.
+
+The software versions being used while writing this guide are:
+- Blender: `v3.6.5`
+- Auto Rig Pro: `v3.68.71`
+
+While older or newer versions may also work, these specific versions were the ones that produced consistent and high-quality results for this process (*you may request Auto Rig Pro authors to provide a download link for previous versions, and they will*)
+
+### Download the character from Mixamo:
+
+First, download any given character of your choice from [Mixamo](https://www.mixamo.com) by selecting a character and clicking on the Download button as in the screenshot below (with Format as `FBX Binary(.fbx)` and Pose as `T-Pose`).
+
+![download from Mixamo](./screenshots/01_download_from_mixamo.png)
+
+### Removing the original Character Armature:
+
+1) After opening Blender, clear your scene by selecting all the objects in your `Scene Collection` > `Collection` by selecting them and pressing the `delete` key;
+
+2) Import your download character to the scene by going to: `File` > `Import` > `gLTF 2.0 (.glb/.gltf)` (*leave all the import options as they are by default*);
+
+3) Select your character's mesh by clicking it on the 3D viewport or by clicking on it on the `Scene Collection` right panel's list (the mesh will be located inside the character's `Armature`, and you can recognize it by the orange triangle icon to the left of its name);
+
+4) After selecting the mesh (an orange outline will appear around it on the 3D viewport), press `Alt + p` with your mouse cursor over the 3D viewport to open the `Clear Parent` menu. Then select the option `Clear and Keep Transformation` as seen in the screenshot below:
+
+![clear parent and keep transformation](./screenshots/02_blender_geometry_clear_and_keep_transformation.png)
+
+5) Once you have done that, you'll see on the `Scene Collection` right panel's list that the character's mesh is not parented to the `Armature` anymore (they became siblings in the list, as seen in the screenshot below), and now you can safely select the `Armature` on the list and press the `delete` key  to delete it;
+
+![delete the original Armature](./screenshots/03_blender_delete_original_armature.png)
+
+6) For good measure, unfold your character's mesh item on the `Scene Collection` right panel's list, click on `Vertex Groups` to select it, and on the lower half of the right panel, first click the `Data` tab (green triangle icon on the left of the panel) click the little down arrow that appears to the right of the `Vertex Groups` list to open the actions menu, and click on `Delete All Groups` (as seen in the screenshot below):
+
+![delete All Vertex Groups](./screenshots/04_blender_delete_all_vertex_groups.png)
+
+
+7) Still for good measure, click on `Modifiers` on the upper part of the `Scene Collection` right panel, and on the lower half of the right panel, first, select the `Modifiers` tab (blue wrench icon), and then click on the X to the right of any Modifier card you may see (as seen in the screenshot below):
+
+![delete Modifiers](./screenshots/05_blender_delete_modifiers.png)
+
+8) Still with your character's mesh selected, place your mouse cursor over the 3D viewport, press `Ctrl + a` to open the `Apply` menu, and then click on `All Transforms` to reset all of your character's transforms (location, rotation, and scale), as seen in the screenshot below:
+
+![Apply All Transforms](./screenshots/06_blender_apply_all_transforms.png)
+
+9) Now open the `App` tab (it stays between the 3D Viewport and the right panel when you drag the little arrow pointing right) to show the `Auto Rig Pro` panel, and with your character's mesh selected, unfold `Auto-Rig Pro: Smart` and then, click on `Get Selected Objects`. You'll then see a `Smart` options selector. Leave it as default (with `Full Body` selected), and then click `OK` as seen in the screenshot below:
+
+![Auto-Rig Pro Smart](./screenshots/07_blender_auto-rig_pro_smart.png)
+
+10) Once that's done, you'll see your character from its front, with an orthographic perspective, and that's to facilitate selecting the key points of your rig on the Auto-Rig Pro rigging process. To start the process, click on `Add Neck` as in the screenshot below:
+
+![Auto-Rig Pro Select Key Points](./screenshots/08_blender_auto-rig_pro_select_key_points.png)
+
+11) Once `Add Neck` is clicked, you'll see your cursor with a green dot on it on the 3D viewport, and you'll use this green dot to mark the key places on your character, which are: `Neck`, `Chin`, `Shoulders`, `Wrists`, `Spine Root`, and `Ankles`. Once you mark the position for each key part of this list, you'll see the button to `Add` the next one. Click it, and mark the next one, until you marked them all. Once you finish this process for all the key places, you'll have a result similar to the screenshot below:
+
+![Auto-Rig Pro Key Points Selected](./screenshots/09_blender_auto-rig_pro_key_points_selected.png)
+
+12) Once you finished that, you'll notice that the Auto-Rig Pro panel has changed and now has further options. Search for the `Skeleton Setting Pressets:` dropdown list option, and use it to select the `UE5 Manny-Quinn` option (as seen in the screenshot above) leaving all the other options as they are by default, and then press the button `Go` (this process may take a few seconds depending on your computer's performance).
+
+13) After doing that, you'll see that your body part markings on the 3D Viewport will be replaced by your New Rig Skeleton (that should be well aligned with your character's mesh, as seen in the screenshot below). Then just click on `Match to Rig` to finish your Rig Creation process (this may also take a few seconds to execute. Please be patient);
+
+![Auto-Rig Pro Match to Rig](./screenshots/10_blender_auto-rig_pro_match_to_rig.png)
+
+
+14) After you see your new Rig on the 3D Viewport, you'll select your character's mesh by clicking it (an orange outline will appear around it), then, while holding the `Shift` key, you'll select your Rig (you can do it by clicking the cyan circle above the character's head). After selecting both, click on the `Skin` tab on the Auto-Rig Pro's panel, look for the `Engine:` dropdown list option, and select `Voxelized` (as seen in the screenshot below) while leaving all the rest of the options as they are by default, and click on the `Bind` button to bind your new Rig to your character's mesh (this may also take a few seconds);
+
+![Auto-Rig Pro Bind Rig](./screenshots/11_blender_auto-rig_pro_bind_rig.png)
+
+15) After doing that, you'll unfold the `Auto-Rig Pro: Export` section, which is the last option on the Auto-Rig Pro panel, and click on the `Export GLTF...` button as in the screenshot below:
+
+![Auto-Rig Export](./screenshots/12_blender_auto-rig_pro_export.png)
+
+16) In the Blender File View, you'll see after clicking on the Export, you'll give your file a name, and carefully check some parameters we need to use to export the file with the right conditions. Please follow the list below:
+
+> 1) Leave `Format:` as it is by default in such file viewer (`gLTF Binary (.glb)`);
+> 2) Right under it, there's a drop-down selector that will probably have `Unity` by default. You'll click on it and select the `Unreal Engine` option;
+> 3) Right under it, select `Humanoid` instead of Universal (which probably is selected by default);
+> 4) Click the `Fix Rig` button, and then click `OK` on the Info panel that will show all the operations that were applied;
+> 5) Right under the `Fix Rig` button, select the `Animations` tab (to the right of the `Rig` tab that is selected by default), and when on it, `unckeck` the `Bake Animations` option (which will probably be checked by default), and then click back on the `Rig` tab so we can configure the remaining options;
+> 6) Back on the `Rig` tab, in the bottom part of the panel, you have to `check` three options to activate them. `check` the options: `Rename for UE`, `Mannequin Axes`, and `Add IK Bones`. Once you enable those three options, you can click on the `Auto-Rig Pro GLTF Exporter` button. In the end of the process, all your options should look like in the screenshot below:
+
+![Auto-Rig Export Options](./screenshots/13_blender_auto-rig_pro_export_options.png)
+
+
+17) Now that you have your file properly rigged and exported from Blender, you're ready to open the [**`gltf-avatar-exporter`**](https://mml-io.github.io/avatar-tools/main/tools/gltf-avatar-exporter/) Avatar Tool, and then you just need to drag the file you just exported to the top-left quadrant of the tool. You'll then see the preview of your model, and if you want to, you may click on the `Use Sample Animation` and `Toggle Slow Motion` buttons to preview your character with an animation playing to see how your new Rig deforms. You may also `uncheck` the `Debug` options (in the lower part of the top-right quadrant of the tool) to disable the debugging lines on the preview viewport. Once you're happy previewing your file, click on the `Export` button, as seen in the screenshot below:
+
+![GLTF Avatar Exporter Tool](./screenshots/14_gltf-avatar-exporter_tool.png)
+
+18) Now you can navigate to the [MML Editor](https://mmleditor.com), where you'll click on the `Create Project` button, as seen in the screenshot below:
+
+![MML Editor](./screenshots/15_mml_editor.png)
+
+19) Once your New Project window is open, just drag the file you just exported from the `GLTF Avatar Exporter Tool` to upload the asset to the `MML Editor`, and then click on the `Upload` button.
+
+20) Once uploaded, you may find your asset on the `Assets` tab (on the upper-left part of the screen, to the right of the `Scene` tab), and then you can drag its card from the `Assets` list and drop it on the lower-left quadrant of the `MML Editor`, as seen in the screenshot below. By doing that, you'll immediately see the `<m-model>` tag with an `src` atribute that contains an `mmlstorage URL` to your model, and you'll also see your character appearing on both of the top quadrants of the screen.
+
+21) Now, on the `CODE` quadrant (the lower-left one), rename both the opening and closing `<m-model>` tags to `<m-character>` tags, as seen in the screenshot below. After renaming the tags, click on the `Static Versions` button on the upper right part of the screen;
+
+
+![MML Editor <m-character> tags](./screenshots/16_mml_editor_m-character.png)
+
+22) After clicking the `Static Versions` button, you'll see the `Static Versions` modal. Then you may click on the `Publish` button to publish your MML Document, and you'll immediately see the `Existing Static Versions` list with your published static MML Document, where you can click the `Copy` button to copy the URL of your MML document to your clipboard. That's the address you'll use to import your MML Character to any M-Squared Experiences.
+
+![MML Editor Publish](./screenshots/17_mml_editor_publish.png)
+
+🥳🎉 **Congratulations!** Now you have your static `MML Document` published through the `MML Editor` ready to use. Have fun!

--- a/tools/gltf-avatar-exporter/docs/screenshots/01_download_from_mixamo.png
+++ b/tools/gltf-avatar-exporter/docs/screenshots/01_download_from_mixamo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a68897b315668772fddfeca9e1ab11d88067d6276f260ea4e8e1ea1b7b97e8e0
+size 568283

--- a/tools/gltf-avatar-exporter/docs/screenshots/02_blender_geometry_clear_and_keep_transformation.png
+++ b/tools/gltf-avatar-exporter/docs/screenshots/02_blender_geometry_clear_and_keep_transformation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06218eb32ad175aadc68cdbd311da4020dc774e2b968338d3aa1d7af918c6b87
+size 772051

--- a/tools/gltf-avatar-exporter/docs/screenshots/03_blender_delete_original_armature.png
+++ b/tools/gltf-avatar-exporter/docs/screenshots/03_blender_delete_original_armature.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7df274258536432914b359e798ff200d538caa208aad43d711ce4a195d48200c
+size 605782

--- a/tools/gltf-avatar-exporter/docs/screenshots/04_blender_delete_all_vertex_groups.png
+++ b/tools/gltf-avatar-exporter/docs/screenshots/04_blender_delete_all_vertex_groups.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24b12342a265d8cf28e45e249aa635526bea6edaeb7fc27c4d2a94a4ada0b47d
+size 697447

--- a/tools/gltf-avatar-exporter/docs/screenshots/05_blender_delete_modifiers.png
+++ b/tools/gltf-avatar-exporter/docs/screenshots/05_blender_delete_modifiers.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e742a24af8a942d8ff27f91ea85c6a5bdd1bd91335b9133ed984c0b525527aa
+size 611553

--- a/tools/gltf-avatar-exporter/docs/screenshots/06_blender_apply_all_transforms.png
+++ b/tools/gltf-avatar-exporter/docs/screenshots/06_blender_apply_all_transforms.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21dcd08d31f8306eb06f33392213765e199b2fea77a4c1f3037c1c03d77fdc59
+size 591141

--- a/tools/gltf-avatar-exporter/docs/screenshots/07_blender_auto-rig_pro_smart.png
+++ b/tools/gltf-avatar-exporter/docs/screenshots/07_blender_auto-rig_pro_smart.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f20050a34d4350c9e90a6dd3efa80511531d925cb399e3fb58d0fcd0ed24d7cf
+size 619938

--- a/tools/gltf-avatar-exporter/docs/screenshots/08_blender_auto-rig_pro_select_key_points.png
+++ b/tools/gltf-avatar-exporter/docs/screenshots/08_blender_auto-rig_pro_select_key_points.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8220b5add696c180a647361c5a2894eba5b5417030abe384ffa6ab708b864b7
+size 618779

--- a/tools/gltf-avatar-exporter/docs/screenshots/09_blender_auto-rig_pro_key_points_selected.png
+++ b/tools/gltf-avatar-exporter/docs/screenshots/09_blender_auto-rig_pro_key_points_selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c0cf15eda6cfba0946c1d384b16680613061e597de5589bd502c587352e0ee4
+size 664129

--- a/tools/gltf-avatar-exporter/docs/screenshots/10_blender_auto-rig_pro_match_to_rig.png
+++ b/tools/gltf-avatar-exporter/docs/screenshots/10_blender_auto-rig_pro_match_to_rig.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5cc55a87f5031ecbc91bef5adb86332f88f023adeb863915ac937f154064dcce
+size 684143

--- a/tools/gltf-avatar-exporter/docs/screenshots/11_blender_auto-rig_pro_bind_rig.png
+++ b/tools/gltf-avatar-exporter/docs/screenshots/11_blender_auto-rig_pro_bind_rig.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:817e66135c33d5d3e8820b5142cfe988ce3b443d1d59ca8d6eaedcaca7ad8f65
+size 791154

--- a/tools/gltf-avatar-exporter/docs/screenshots/12_blender_auto-rig_pro_export.png
+++ b/tools/gltf-avatar-exporter/docs/screenshots/12_blender_auto-rig_pro_export.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eec3d7ca1637ef14ff1af16dec63a410d656141542d1deaee65f416b8dd61e4f
+size 712353

--- a/tools/gltf-avatar-exporter/docs/screenshots/13_blender_auto-rig_pro_export_options.png
+++ b/tools/gltf-avatar-exporter/docs/screenshots/13_blender_auto-rig_pro_export_options.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14759ce7397ae87c1ef195d09dfc0055540c9922a019c7cc452beddd9d9fa7ba
+size 569734

--- a/tools/gltf-avatar-exporter/docs/screenshots/14_gltf-avatar-exporter_tool.png
+++ b/tools/gltf-avatar-exporter/docs/screenshots/14_gltf-avatar-exporter_tool.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf855e1c241c66199f2f2bddad1b2bb749185be3e3e3d762ae8fea31b66f4d6b
+size 799241

--- a/tools/gltf-avatar-exporter/docs/screenshots/15_mml_editor.png
+++ b/tools/gltf-avatar-exporter/docs/screenshots/15_mml_editor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07c08e03e07b382fdac652103e0586f77d10f06ef0dd451f5da647ba4ea081f4
+size 243257

--- a/tools/gltf-avatar-exporter/docs/screenshots/16_mml_editor_m-character.png
+++ b/tools/gltf-avatar-exporter/docs/screenshots/16_mml_editor_m-character.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:899eae7b14a39f78095b931f7f78c6d682b472a4654240c58e608ce5b3a00e51
+size 389039

--- a/tools/gltf-avatar-exporter/docs/screenshots/17_mml_editor_publish.png
+++ b/tools/gltf-avatar-exporter/docs/screenshots/17_mml_editor_publish.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76c7bd064adeb06c17de8e12a54594230cf1d8736dfd62bea4131d82afad9350
+size 367057


### PR DESCRIPTION
This PR aims to offer a basic user guide for the `gltf-avatar-exporter` tool to convert assets from sources like Mixamo (used as an example in the guide) into assets that are usable in Unreal experiences

**What kind of change does your PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Tests
- [X] Other, please describe:

Documentation

**Does your PR fulfill the following requirements?**

- [ ] The title references the corresponding issue # (if relevant)
