### PR TITLE
Adds CLI options for skipping correction steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ you can use the tool to process avatars using the following command from the roo
 ```bash
 npm run convert -- -i <input file> -o <output file>
 ```
+
+The CLI tool supports skipping [correction steps](./packages/gltf-avatar-export-lib/src/correction-steps/) by name:
+```bash
+# Skip the "remove-transparency-from-materials" step
+npm run convert -- -i <input file> -o <output file> --skip-remove-transparency-from-materials
+```

--- a/packages/gltf-avatar-export-lib/src/correction-steps/bone-deduping.ts
+++ b/packages/gltf-avatar-export-lib/src/correction-steps/bone-deduping.ts
@@ -1,11 +1,11 @@
 import * as THREE from "three";
 import { Group } from "three";
 
-import { Step } from "./types";
+import { StepResult } from "./types";
 
-export const boneDedupingCorrectionStep: Step = {
-  name: "boneDeduping",
-  action: (group: Group) => {
+export const boneDedupingCorrectionStep = {
+  name: "bone-deduping",
+  action: (group: Group): StepResult => {
     const toRemove: Array<THREE.Bone> = [];
     const bonesByName = new Map<string, THREE.Bone>();
     group.traverse((child) => {
@@ -57,4 +57,4 @@ export const boneDedupingCorrectionStep: Step = {
       },
     };
   },
-};
+} as const;

--- a/packages/gltf-avatar-export-lib/src/correction-steps/connect-root.ts
+++ b/packages/gltf-avatar-export-lib/src/correction-steps/connect-root.ts
@@ -1,11 +1,11 @@
 import * as THREE from "three";
 import { Group } from "three";
 
-import { LogMessage, Step } from "./types";
+import { LogMessage, Step, StepResult } from "./types";
 
-export const connectRootCorrectionStep: Step = {
-  name: "connectRoot",
-  action: (group: Group) => {
+export const connectRootCorrectionStep = {
+  name: "connect-root",
+  action: (group: Group): StepResult => {
     const rootBone = group.getObjectByName("root") as THREE.Bone;
     if (!rootBone) {
       return {
@@ -50,4 +50,4 @@ export const connectRootCorrectionStep: Step = {
       logs,
     };
   },
-};
+} as const;

--- a/packages/gltf-avatar-export-lib/src/correction-steps/fix-bones-scale.ts
+++ b/packages/gltf-avatar-export-lib/src/correction-steps/fix-bones-scale.ts
@@ -2,14 +2,14 @@ import * as THREE from "three";
 import { Group } from "three";
 
 import { getBonesBoundingBox } from "./getBonesBoundingBox";
-import { LogMessage, Step } from "./types";
+import { LogMessage, Step, StepResult } from "./types";
 
 const scaleCorrection = new THREE.Matrix4().makeScale(0.01, 0.01, 0.01);
 const scaleKCorrection = new THREE.Matrix4().makeScale(0.001, 0.001, 0.001);
 
-export const fixBonesScaleCorrectionStep: Step = {
-  name: "fixBonesScale",
-  action: (group: Group) => {
+export const fixBonesScaleCorrectionStep = {
+  name: "fix-bones-scale",
+  action: (group: Group): StepResult => {
     const bonesBoundingBox = getBonesBoundingBox(group);
     const xBonesSize = bonesBoundingBox.max.x - bonesBoundingBox.min.x;
     const yBonesSize = bonesBoundingBox.max.y - bonesBoundingBox.min.y;
@@ -55,4 +55,4 @@ export const fixBonesScaleCorrectionStep: Step = {
       logs: [bonesSizeLog],
     };
   },
-};
+} as const;

--- a/packages/gltf-avatar-export-lib/src/correction-steps/fix-flipped-bitmap-textures.ts
+++ b/packages/gltf-avatar-export-lib/src/correction-steps/fix-flipped-bitmap-textures.ts
@@ -2,7 +2,7 @@ import * as THREE from "three";
 import { Group, Texture } from "three";
 
 import { forEachMapKey } from "./materials/forEachMapKey";
-import { Step } from "./types";
+import { StepResult } from "./types";
 
 function fixTexture(texture: Texture): Texture | null {
   if (
@@ -52,9 +52,9 @@ function fixMaterial(material: THREE.Material): Array<string> {
   return flippedTextures;
 }
 
-export const fixFlippedBitmapTexturesCorrectionStep: Step = {
-  name: "fixFlippedBitmapTextures",
-  action: (group: Group) => {
+export const fixFlippedBitmapTexturesCorrectionStep = {
+  name: "fix-flipped-bitmap-textures",
+  action: (group: Group): StepResult => {
     const flippedTextureNames: Array<string> = [];
 
     group.traverse((child) => {
@@ -104,4 +104,4 @@ export const fixFlippedBitmapTexturesCorrectionStep: Step = {
       })),
     };
   },
-};
+} as const;

--- a/packages/gltf-avatar-export-lib/src/correction-steps/fix-mesh-scale.ts
+++ b/packages/gltf-avatar-export-lib/src/correction-steps/fix-mesh-scale.ts
@@ -2,14 +2,14 @@ import * as THREE from "three";
 import { Group } from "three";
 
 import { getBonesBoundingBox } from "./getBonesBoundingBox";
-import { LogMessage, Step } from "./types";
+import { LogMessage, Step, StepResult } from "./types";
 
 const scaleCorrection = new THREE.Matrix4().makeScale(0.01, 0.01, 0.01);
 const scaleKCorrection = new THREE.Matrix4().makeScale(0.001, 0.001, 0.001);
 
-export const fixMeshScaleCorrectionStep: Step = {
-  name: "fixMeshScale",
-  action: (group: Group) => {
+export const fixMeshScaleCorrectionStep = {
+  name: "fix-mesh-scale",
+  action: (group: Group): StepResult => {
     /*
      Detect the bone sizes to determine if we need to apply the scaling to the mesh. The mesh itself might be too small
     */
@@ -57,4 +57,4 @@ export const fixMeshScaleCorrectionStep: Step = {
       logs: [bonesSizeLog],
     };
   },
-};
+} as const;

--- a/packages/gltf-avatar-export-lib/src/correction-steps/index.ts
+++ b/packages/gltf-avatar-export-lib/src/correction-steps/index.ts
@@ -1,24 +1,25 @@
-import { boneDedupingCorrectionStep } from "./boneDeduping";
-import { connectRootCorrectionStep } from "./connectRoot";
-import { fixFlippedBitmapTexturesCorrectionStep } from "./fixBitmapTextures";
-import { fixBonesScaleCorrectionStep } from "./fixBonesScale";
-import { fixMeshScaleCorrectionStep } from "./fixMeshScale";
-import { levelOfDetailDedupingCorrectionStep } from "./lodDeduping";
-import { mergeGeometryGroupsCorrectionStep } from "./mergeGeometryGroups";
-import { placeholderMissingTexturesCorrectionStep } from "./placeholderMissingTextures";
-import { removeTransparencyFromMaterialsCorrectionStep } from "./removeTransparencyFromMaterials";
-import { removeVertexColorsCorrectionStep } from "./removeVertexColors";
-import { replaceIncompatibleMaterialsCorrectionStep } from "./replaceIncompatibleMaterials";
-import { reposeBonesCorrectionStep } from "./reposeBones";
-import { rotatePelvisCorrectionStep } from "./rotatePelvis";
-import { rotateRootCorrectionStep } from "./rotateRoot";
-import { rotateWholeGroupCorrectionStep } from "./rotateWholeGroup";
-import { zUpBonesCorrectionStep } from "./zUpBonesCorrectionStep";
-import { zUpMeshCorrectionStep } from "./zUpMeshCorrectionStep";
+import { boneDedupingCorrectionStep } from "./bone-deduping";
+import { connectRootCorrectionStep } from "./connect-root";
+import { fixBonesScaleCorrectionStep } from "./fix-bones-scale";
+import { fixFlippedBitmapTexturesCorrectionStep } from "./fix-flipped-bitmap-textures";
+import { fixMeshScaleCorrectionStep } from "./fix-mesh-scale";
+import { levelOfDetailDedupingCorrectionStep } from "./level-of-detail-deduping";
+import { mergeGeometryGroupsCorrectionStep } from "./merge-geometry-groups";
+import { placeholderMissingTexturesCorrectionStep } from "./placeholder-missing-textures";
+import { removeTransparencyFromMaterialsCorrectionStep } from "./remove-transparency-from-materials";
+import { removeVertexColorsCorrectionStep } from "./remove-vertex-colors";
+import { replaceIncompatibleMaterialsCorrectionStep } from "./replace-incompatible-materials";
+import { reposeBonesCorrectionStep } from "./repose-bones";
+import { rotatePelvisCorrectionStep } from "./rotate-pelvis";
+import { rotateRootCorrectionStep } from "./rotate-root";
+import { rotateWholeGroupCorrectionStep } from "./rotate-whole-group";
+import { Step } from "./types";
+import { zUpBonesCorrectionStep } from "./z-up-bones";
+import { zUpMeshCorrectionStep } from "./z-up-mesh";
 
 export * from "./types";
 
-export const correctionSteps = [
+const rawCorrectionSteps = [
   levelOfDetailDedupingCorrectionStep,
   mergeGeometryGroupsCorrectionStep,
   boneDedupingCorrectionStep,
@@ -36,4 +37,12 @@ export const correctionSteps = [
   placeholderMissingTexturesCorrectionStep,
   replaceIncompatibleMaterialsCorrectionStep,
   removeTransparencyFromMaterialsCorrectionStep,
-];
+] as const;
+
+export const correctionSteps: ReadonlyArray<Readonly<Step>> = rawCorrectionSteps;
+
+export type CorrectionStepName = (typeof correctionSteps)[number]["name"];
+
+export const correctionStepNames: Array<CorrectionStepName> = correctionSteps.map(
+  (step) => step.name,
+);

--- a/packages/gltf-avatar-export-lib/src/correction-steps/level-of-detail-deduping.ts
+++ b/packages/gltf-avatar-export-lib/src/correction-steps/level-of-detail-deduping.ts
@@ -1,11 +1,11 @@
 import * as THREE from "three";
 import { Group } from "three";
 
-import { LogMessage, Step } from "./types";
+import { LogMessage, Step, StepResult } from "./types";
 
-export const levelOfDetailDedupingCorrectionStep: Step = {
-  name: "levelOfDetailDeduping",
-  action: (group: Group) => {
+export const levelOfDetailDedupingCorrectionStep = {
+  name: "level-of-detail-deduping",
+  action: (group: Group): StepResult => {
     const skinnedMeshByName = new Map<string, THREE.SkinnedMesh>();
     const skinnedMeshByLODName = new Map<
       string,
@@ -90,4 +90,4 @@ export const levelOfDetailDedupingCorrectionStep: Step = {
       logs,
     };
   },
-};
+} as const;

--- a/packages/gltf-avatar-export-lib/src/correction-steps/merge-geometry-groups.ts
+++ b/packages/gltf-avatar-export-lib/src/correction-steps/merge-geometry-groups.ts
@@ -4,11 +4,11 @@ import { Group } from "three";
 // eslint-disable-next-line import/no-unresolved
 import * as BufferGeometryUtils from "three/addons/utils/BufferGeometryUtils.js";
 
-import { LogMessage, Step } from "./types";
+import { LogMessage, Step, StepResult } from "./types";
 
-export const mergeGeometryGroupsCorrectionStep: Step = {
-  name: "mergeGeometryGroups",
-  action: (group: Group) => {
+export const mergeGeometryGroupsCorrectionStep = {
+  name: "merge-geometry-groups",
+  action: (group: Group): StepResult => {
     const logs: Array<LogMessage> = [];
 
     group.traverse((child) => {
@@ -57,4 +57,4 @@ export const mergeGeometryGroupsCorrectionStep: Step = {
       logs,
     };
   },
-};
+} as const;

--- a/packages/gltf-avatar-export-lib/src/correction-steps/placeholder-missing-textures.ts
+++ b/packages/gltf-avatar-export-lib/src/correction-steps/placeholder-missing-textures.ts
@@ -2,7 +2,7 @@ import * as THREE from "three";
 import { Group, Texture } from "three";
 
 import { forEachMapKey } from "./materials/forEachMapKey";
-import { Step } from "./types";
+import { StepResult } from "./types";
 
 function fixTexture(texture: Texture, setDefaultColorIfMissing: boolean = false): Texture | null {
   if (!texture.image || texture.image.data === null) {
@@ -34,9 +34,9 @@ function fixMaterial(material: THREE.Material): Array<string> {
   return missingTextures;
 }
 
-export const placeholderMissingTexturesCorrectionStep: Step = {
-  name: "placeholderMissingTextures",
-  action: (group: Group) => {
+export const placeholderMissingTexturesCorrectionStep = {
+  name: "placeholder-missing-textures",
+  action: (group: Group): StepResult => {
     const missingTextureNames: Array<string> = [];
 
     group.traverse((child) => {
@@ -86,4 +86,4 @@ export const placeholderMissingTexturesCorrectionStep: Step = {
       })),
     };
   },
-};
+} as const;

--- a/packages/gltf-avatar-export-lib/src/correction-steps/remove-vertex-colors.ts
+++ b/packages/gltf-avatar-export-lib/src/correction-steps/remove-vertex-colors.ts
@@ -1,11 +1,11 @@
 import * as THREE from "three";
 import { Group } from "three";
 
-import { LogMessage, Step } from "./types";
+import { LogMessage, Step, StepResult } from "./types";
 
-export const removeVertexColorsCorrectionStep: Step = {
-  name: "removeVertexColors",
-  action: (group: Group) => {
+export const removeVertexColorsCorrectionStep = {
+  name: "remove-vertex-colors",
+  action: (group: Group): StepResult => {
     const logs: Array<LogMessage> = [];
     group.traverse((child) => {
       const asSkinnedMesh = child as THREE.SkinnedMesh;
@@ -41,4 +41,4 @@ export const removeVertexColorsCorrectionStep: Step = {
       logs: logs,
     };
   },
-};
+} as const;

--- a/packages/gltf-avatar-export-lib/src/correction-steps/repose-bones.ts
+++ b/packages/gltf-avatar-export-lib/src/correction-steps/repose-bones.ts
@@ -1,11 +1,11 @@
 import * as THREE from "three";
 import { Group } from "three";
 
-import { LogMessage, Step } from "./types";
+import { LogMessage, Step, StepResult } from "./types";
 
-export const reposeBonesCorrectionStep: Step = {
-  name: "reposeBones",
-  action: (group: Group) => {
+export const reposeBonesCorrectionStep = {
+  name: "repose-bones",
+  action: (group: Group): StepResult => {
     const logs: Array<LogMessage> = [];
 
     group.traverse((child) => {
@@ -50,4 +50,4 @@ export const reposeBonesCorrectionStep: Step = {
       logs,
     };
   },
-};
+} as const;

--- a/packages/gltf-avatar-export-lib/src/correction-steps/rotate-pelvis.ts
+++ b/packages/gltf-avatar-export-lib/src/correction-steps/rotate-pelvis.ts
@@ -2,7 +2,7 @@ import * as THREE from "three";
 import { Group } from "three";
 
 import { reposeSkinnedMeshes } from "./reposeSkinnedMeshes";
-import { Step } from "./types";
+import { StepResult } from "./types";
 
 function isNear(a: number, b: number, epsilon = 0.1) {
   return Math.abs(a - b) < epsilon;
@@ -11,9 +11,9 @@ function isNear(a: number, b: number, epsilon = 0.1) {
 const HalfPi = Math.PI / 2;
 
 // TODO - there are some cases where this doesn't work - and the added rotation potentially overcorrects.
-export const rotatePelvisCorrectionStep: Step = {
-  name: "rotatePelvis",
-  action: (group: Group) => {
+export const rotatePelvisCorrectionStep = {
+  name: "rotate-pelvis",
+  action: (group: Group): StepResult => {
     const pelvisBone = group.getObjectByName("pelvis") as THREE.Bone;
     if (!pelvisBone) {
       return {
@@ -105,4 +105,4 @@ export const rotatePelvisCorrectionStep: Step = {
       },
     };
   },
-};
+} as const;

--- a/packages/gltf-avatar-export-lib/src/correction-steps/rotate-root.ts
+++ b/packages/gltf-avatar-export-lib/src/correction-steps/rotate-root.ts
@@ -1,7 +1,7 @@
 import * as THREE from "three";
 import { Group } from "three";
 
-import { Step } from "./types";
+import { StepResult } from "./types";
 
 function isNear(a: number, b: number, epsilon = 0.1) {
   return Math.abs(a - b) < epsilon;
@@ -9,9 +9,9 @@ function isNear(a: number, b: number, epsilon = 0.1) {
 
 const HalfPi = Math.PI / 2;
 
-export const rotateRootCorrectionStep: Step = {
-  name: "rotateRoot",
-  action: (group: Group) => {
+export const rotateRootCorrectionStep = {
+  name: "rotate-root",
+  action: (group: Group): StepResult => {
     const rootBone = group.getObjectByName("root") as THREE.Bone;
     if (!rootBone) {
       return {
@@ -78,4 +78,4 @@ export const rotateRootCorrectionStep: Step = {
       };
     }
   },
-};
+} as const;

--- a/packages/gltf-avatar-export-lib/src/correction-steps/rotate-whole-group.ts
+++ b/packages/gltf-avatar-export-lib/src/correction-steps/rotate-whole-group.ts
@@ -1,10 +1,10 @@
 import { Group } from "three";
 
-import { Step } from "./types";
+import { StepResult } from "./types";
 
-export const rotateWholeGroupCorrectionStep: Step = {
-  name: "rotateWholeGroup",
-  action: (group: Group) => {
+export const rotateWholeGroupCorrectionStep = {
+  name: "rotate-whole-group",
+  action: (group: Group): StepResult => {
     if (group.rotation.x === 0 && group.rotation.y === 0 && group.rotation.z === 0) {
       return {
         didApply: false,
@@ -25,4 +25,4 @@ export const rotateWholeGroupCorrectionStep: Step = {
       topLevelMessage: { level: "info", message: "Rotated whole imported group to 0,0,0" },
     };
   },
-};
+} as const;

--- a/packages/gltf-avatar-export-lib/src/correction-steps/targetBoneTransformations.ts
+++ b/packages/gltf-avatar-export-lib/src/correction-steps/targetBoneTransformations.ts
@@ -90,4 +90,4 @@ export const targetBoneTransformations: {
   ik_hand_r: { pos: [0.0, 0.0, 0.0], rot: [0.0, 0.0, 0.0, 1.0] },
   interaction: { pos: [0.0, 0.0, 0.0], rot: [0.0, 0.0, 0.0, 1.0] },
   center_of_mass: { pos: [0.0, 0.0, 0.0], rot: [0.0, 0.0, 0.0, 1.0] },
-};
+} as const;

--- a/packages/gltf-avatar-export-lib/src/correction-steps/types.ts
+++ b/packages/gltf-avatar-export-lib/src/correction-steps/types.ts
@@ -13,6 +13,6 @@ export type StepResult = {
 };
 
 export type Step = {
-  name: string;
+  readonly name: string;
   action: (group: Group) => StepResult;
 };

--- a/packages/gltf-avatar-export-lib/src/correction-steps/z-up-mesh.ts
+++ b/packages/gltf-avatar-export-lib/src/correction-steps/z-up-mesh.ts
@@ -1,14 +1,17 @@
-import { Group } from "three";
 import * as THREE from "three";
+import { Group } from "three";
 
 import { getBonesBoundingBox } from "./getBonesBoundingBox";
-import { LogMessage, Step } from "./types";
+import { LogMessage, Step, StepResult } from "./types";
 
 const zUpCorrection = new THREE.Matrix4().makeRotationX(-Math.PI / 2);
 
-export const zUpBonesCorrectionStep: Step = {
-  name: "zUpBones",
-  action: (group: Group) => {
+export const zUpMeshCorrectionStep = {
+  name: "z-up-mesh",
+  action: (group: Group): StepResult => {
+    /*
+     Detect the bone sizes to determine if we need to apply the scaling to the mesh. The mesh itself might be too small
+    */
     const bonesBoundingBox = getBonesBoundingBox(group);
     const xBonesSize = bonesBoundingBox.max.x - bonesBoundingBox.min.x;
     const yBonesSize = bonesBoundingBox.max.y - bonesBoundingBox.min.y;
@@ -17,8 +20,8 @@ export const zUpBonesCorrectionStep: Step = {
       level: "info",
       message: `Bones size: x: ${xBonesSize}, y: ${yBonesSize}, z: ${zBonesSize}`,
     };
-    const bonesAreZUp = zBonesSize > yBonesSize;
-    if (!bonesAreZUp) {
+    const meshIsZUp = zBonesSize > yBonesSize;
+    if (!meshIsZUp) {
       return {
         didApply: false,
         logs: [bonesSizeLog],
@@ -30,17 +33,9 @@ export const zUpBonesCorrectionStep: Step = {
     }
 
     group.traverse((child) => {
-      const asBone = child as THREE.Bone;
-      if (asBone.isBone) {
-        if (child.name === "root") {
-          /*
-           If the skeleton is Z-up, apply the matrix transformation to the immediate children of the root bone. This is
-           cleaner that rotating the root itself.
-          */
-          child.children.forEach((innerChild) => {
-            innerChild.applyMatrix4(zUpCorrection);
-          });
-        }
+      const asSkinnedMesh = child as THREE.SkinnedMesh;
+      if (asSkinnedMesh.isSkinnedMesh) {
+        asSkinnedMesh.geometry.applyMatrix4(zUpCorrection);
       }
     });
 
@@ -48,9 +43,9 @@ export const zUpBonesCorrectionStep: Step = {
       didApply: true,
       topLevelMessage: {
         level: "info",
-        message: "Detected bones were z-up (height was in z axis). Rotated to make height y axis.",
+        message: "Detected mesh was z-up (height was in z axis). Rotated to make height y axis.",
       },
       logs: [bonesSizeLog],
     };
   },
-};
+} as const;


### PR DESCRIPTION
This PR adds the ability to skip correction steps by name when using the CLI.

E.g. `npm run convert -- --skip-remove-transparency-from-materials [...]`

It also refactors the correction steps to make the naming of the files and steps consistent with the arguments (dash-case).

**What kind of change does your PR introduce?** (check at least one)

- [x] Feature
- [x] Refactor